### PR TITLE
docs: add copyright clause and address legal review findings

### DIFF
--- a/PRIVACY_EN.md
+++ b/PRIVACY_EN.md
@@ -1,7 +1,7 @@
 # Privacy Policy
 
 **My Food Forest B.V.**  
-Last updated: June 4, 2026
+Last updated: June 5, 2026
 
 ## 1. Introduction
 
@@ -31,9 +31,12 @@ Chamber of Commerce number: 96517557
 **In the App:**
 
 - Account registration details (name, email address, username)
-- Profile information (location, gardening experience, preferences)
+- Profile information (the general location or region you enter yourself, gardening experience, preferences)
 - Content you create (posts, photos, comments, plant and harvest records)
+- Verification details, if we ask you to verify your identity or contact information (such as confirming your email address)
 - Communication with us (support requests, feedback)
+
+Photos can contain hidden metadata, such as the GPS location where they were taken (EXIF data). We automatically remove this location metadata from photos when you upload them.
 
 **On the Website:**
 
@@ -87,8 +90,11 @@ Third-party companies that help us operate our Services:
 - **Microsoft Azure** — cloud hosting and infrastructure for our Services
 - **Microsoft Entra External ID** — account sign-in and authentication
 - **Microsoft Forms** — beta program sign-up forms on the Website
+- **Mailchimp (Intuit Inc.)** — sending our newsletter
 
 We have data processing agreements in place with our processors as required by Article 28 GDPR.
+
+We also share the location of your food forest (not your identity) with external weather data providers to retrieve local weather information (see Section 3.4).
 
 ### 6.2 Legal Requirements
 
@@ -97,7 +103,7 @@ We may disclose your information when required by law or to:
 - Comply with legal processes or government requests
 - Protect our rights, property, or safety
 - Prevent fraud or security threats
-- Enforce our terms of service
+- Enforce our Terms and Conditions
 
 ### 6.3 Business Transfers
 
@@ -107,9 +113,9 @@ We do not sell your personal data, and we do not share it with third parties for
 
 ## 7. International Data Transfers
 
-Our Services are hosted on Microsoft Azure in the European Union. Where Microsoft processes limited data outside the European Economic Area (EEA) (for example for support or service operations), we ensure adequate protection through:
+Our Services are hosted on Microsoft Azure in the European Union. Where our service providers process limited data outside the European Economic Area (EEA) (for example, Microsoft for support or service operations, or Mailchimp for sending our newsletter), we ensure adequate protection through:
 
-- Microsoft's compliance with GDPR and Standard Contractual Clauses
+- Our providers' compliance with GDPR and Standard Contractual Clauses
 - Adequacy decisions by the European Commission (including the EU-US Data Privacy Framework, where applicable)
 - Other appropriate safeguards as required by law
 
@@ -128,6 +134,8 @@ Specific retention periods:
 - **Support and contact communications**: 3 years
 - **Newsletter subscription**: Until you unsubscribe
 - **Financial records (if applicable)**: 7 years (Dutch legal requirement)
+
+If we terminate your account in accordance with our Terms and Conditions (for example, for violations or after prolonged inactivity), the same deletion periods apply from the date of termination.
 
 ## 9. Your Rights Under GDPR
 
@@ -161,7 +169,7 @@ Object to processing based on legitimate interests or for direct marketing.
 
 Withdraw consent at any time where processing is based on consent (for example, location access via your device settings, or the newsletter via the unsubscribe link).
 
-To exercise these rights, contact us at <hello@myfoodforest.nl>. We will respond within one month of receiving your request.
+To exercise these rights, contact us at <hello@myfoodforest.nl>. We will respond within one month of receiving your request. For complex or numerous requests, we may extend this period by up to two further months; if so, we will inform you within the first month.
 
 ## 10. Data Security
 
@@ -196,7 +204,7 @@ The App does **not** use:
 - Third-party analytics or advertising SDKs
 - Device fingerprinting
 
-**Legal basis**: Strictly necessary storage is exempt from the consent requirement; we rely on our legitimate interest in providing a secure, functioning service.
+**Legal basis**: Strictly necessary storage is exempt from the consent requirement; for the underlying processing we rely on the performance of our contract with you and on our legitimate interest in providing a secure, functioning service.
 
 ### 11.3 Changes to Our Use of Cookies
 
@@ -231,6 +239,8 @@ Postbus 93374
 The Netherlands  
 Website: autoriteitpersoonsgegevens.nl
 
+If you live in another EU member state, you may also lodge a complaint with the data protection authority of your own country.
+
 ## 16. Changes to This Policy
 
 We may update this privacy policy from time to time. We will notify you of significant changes through:
@@ -249,3 +259,6 @@ Email: <hello@myfoodforest.nl>
 ---
 
 *This privacy policy is available in [Dutch](./PRIVACY_NL.md).*
+
+**Document Version**: 1.1  
+**Effective Date**: June 5, 2026

--- a/PRIVACY_NL.md
+++ b/PRIVACY_NL.md
@@ -1,7 +1,7 @@
 # Privacyverklaring
 
 **My Food Forest B.V.**  
-Laatst bijgewerkt: 4 juni 2026
+Laatst bijgewerkt: 5 juni 2026
 
 ## 1. Inleiding
 
@@ -30,9 +30,12 @@ Kamer van Koophandel nummer: 96517557
 **In de App:**
 
 - Accountregistratiegegevens (naam, e-mailadres, gebruikersnaam)
-- Profielinformatie (locatie, tuinierervaring, voorkeuren)
+- Profielinformatie (de algemene locatie of regio die u zelf invoert, tuinierervaring, voorkeuren)
 - Inhoud die u creëert (berichten, foto's, opmerkingen, plant- en oogstregistraties)
+- Verificatiegegevens, als wij u vragen uw identiteit of contactgegevens te verifiëren (zoals het bevestigen van uw e-mailadres)
 - Communicatie met ons (supportverzoeken, feedback)
+
+Foto's kunnen verborgen metadata bevatten, zoals de GPS-locatie waar ze zijn gemaakt (EXIF-gegevens). Wij verwijderen deze locatiemetadata automatisch uit foto's wanneer u ze uploadt.
 
 **Op de Website:**
 
@@ -86,8 +89,11 @@ Externe bedrijven die ons helpen onze Diensten te exploiteren:
 - **Microsoft Azure** — cloudhosting en infrastructuur voor onze Diensten
 - **Microsoft Entra External ID** — inloggen en authenticatie
 - **Microsoft Forms** — aanmeldformulieren voor het betaprogramma op de Website
+- **Mailchimp (Intuit Inc.)** — versturen van onze nieuwsbrief
 
 Met onze verwerkers hebben wij verwerkersovereenkomsten gesloten zoals vereist door artikel 28 AVG.
+
+Daarnaast delen wij de locatie van uw voedselbos (niet uw identiteit) met externe weergegevensaanbieders om lokale weersinformatie op te halen (zie artikel 3.4).
 
 ### 6.2 Wettelijke Vereisten
 
@@ -96,7 +102,7 @@ Wij kunnen uw informatie openbaar maken wanneer vereist door de wet of om:
 - Te voldoen aan juridische procedures of overheidsverzoeken
 - Onze rechten, eigendom of veiligheid te beschermen
 - Fraude of beveiligingsbedreigingen te voorkomen
-- Onze servicevoorwaarden af te dwingen
+- Onze Algemene Voorwaarden af te dwingen
 
 ### 6.3 Bedrijfsoverdrachten
 
@@ -106,9 +112,9 @@ Wij verkopen uw persoonsgegevens niet en delen deze niet met derden voor marketi
 
 ## 7. Internationale Gegevensoverdrachten
 
-Onze Diensten worden gehost op Microsoft Azure binnen de Europese Unie. Waar Microsoft beperkte gegevens buiten de Europese Economische Ruimte (EER) verwerkt (bijvoorbeeld voor support of servicebeheer), zorgen wij voor adequate bescherming door:
+Onze Diensten worden gehost op Microsoft Azure binnen de Europese Unie. Waar onze dienstverleners beperkte gegevens buiten de Europese Economische Ruimte (EER) verwerken (bijvoorbeeld Microsoft voor support of servicebeheer, of Mailchimp voor het versturen van onze nieuwsbrief), zorgen wij voor adequate bescherming door:
 
-- Microsoft's naleving van de AVG en Standaard Contractuele Clausules
+- Naleving van de AVG en Standaard Contractuele Clausules door onze dienstverleners
 - Adequaatheidsbesluiten van de Europese Commissie (waaronder het EU-VS Data Privacy Framework, waar van toepassing)
 - Andere passende waarborgen zoals vereist door de wet
 
@@ -127,6 +133,8 @@ Specifieke bewaartermijnen:
 - **Support- en contactcommunicatie**: 3 jaar
 - **Nieuwsbriefinschrijving**: Tot u zich afmeldt
 - **Financiële gegevens (indien van toepassing)**: 7 jaar (Nederlandse wettelijke vereiste)
+
+Als wij uw account beëindigen op grond van onze Algemene Voorwaarden (bijvoorbeeld wegens schendingen of na langdurige inactiviteit), gelden dezelfde verwijderingstermijnen vanaf de datum van beëindiging.
 
 ## 9. Uw Rechten Onder de AVG
 
@@ -160,7 +168,7 @@ Bezwaar maken tegen verwerking op basis van gerechtvaardigd belang of voor direc
 
 Toestemming op elk moment intrekken waar verwerking gebaseerd is op toestemming (bijvoorbeeld locatietoegang via uw apparaatinstellingen, of de nieuwsbrief via de afmeldlink).
 
-Om deze rechten uit te oefenen, neem contact met ons op via <hello@myfoodforest.nl>. Wij zullen binnen één maand na ontvangst van uw verzoek reageren.
+Om deze rechten uit te oefenen, neem contact met ons op via <hello@myfoodforest.nl>. Wij zullen binnen één maand na ontvangst van uw verzoek reageren. Bij complexe of talrijke verzoeken kunnen wij deze termijn met maximaal twee maanden verlengen; in dat geval informeren wij u hierover binnen de eerste maand.
 
 ## 10. Gegevensbeveiliging
 
@@ -195,7 +203,7 @@ De App gebruikt **geen**:
 - Analytics- of advertentie-SDK's van derden
 - Device fingerprinting
 
-**Rechtsgrondslag**: Strikt noodzakelijke opslag is vrijgesteld van het toestemmingsvereiste; wij baseren ons op ons gerechtvaardigd belang bij een veilige, goed functionerende dienst.
+**Rechtsgrondslag**: Strikt noodzakelijke opslag is vrijgesteld van het toestemmingsvereiste; voor de onderliggende verwerking baseren wij ons op de uitvoering van onze overeenkomst met u en op ons gerechtvaardigd belang bij een veilige, goed functionerende dienst.
 
 ### 11.3 Wijzigingen in Ons Cookiegebruik
 
@@ -230,6 +238,8 @@ Postbus 93374
 Nederland  
 Website: autoriteitpersoonsgegevens.nl
 
+Woont u in een andere EU-lidstaat, dan kunt u ook een klacht indienen bij de gegevensbeschermingsautoriteit van uw eigen land.
+
 ## 16. Wijzigingen in Deze Verklaring
 
 Wij kunnen deze privacyverklaring van tijd tot tijd bijwerken. Wij zullen u op de hoogte stellen van significante wijzigingen via:
@@ -248,3 +258,6 @@ E-mail: <hello@myfoodforest.nl>
 ---
 
 *Deze privacyverklaring is beschikbaar in het [Engels](./PRIVACY_EN.md).*
+
+**Documentversie**: 1.1  
+**Ingangsdatum**: 5 juni 2026

--- a/TERMSANDCONDITIONS_EN.md
+++ b/TERMSANDCONDITIONS_EN.md
@@ -329,4 +329,4 @@ By using our Services, you acknowledge that you have read, understood, and agree
 *These Terms and Conditions are available in [Dutch](./TERMSANDCONDITIONS_NL.md).*
 
 **Document Version**: 1.2  
-**Effective Date**: July 5, 2026
+**Effective Date**: June 5, 2026

--- a/TERMSANDCONDITIONS_EN.md
+++ b/TERMSANDCONDITIONS_EN.md
@@ -154,7 +154,7 @@ If you believe that Content on our Services is illegal or infringes your rights 
 - Your name and email address
 - A statement that you believe your report is accurate and submitted in good faith
 
-We will confirm receipt of your report, assess it diligently, timely, and in a non-arbitrary manner, and inform you of our decision. We may stop processing reports from persons who frequently submit manifestly unfounded reports, after first issuing a warning.
+We will confirm receipt of your report, assess it in a timely, diligent, and non-arbitrary manner, and inform you of our decision. We may stop processing reports from persons who frequently submit manifestly unfounded reports, after first issuing a warning.
 
 ## 8. Privacy and Data Protection
 

--- a/TERMSANDCONDITIONS_EN.md
+++ b/TERMSANDCONDITIONS_EN.md
@@ -1,7 +1,7 @@
 # Terms and Conditions
 
 **My Food Forest B.V.**  
-Last updated: June 4, 2026
+Last updated: June 5, 2026
 
 ## 1. Introduction and Acceptance
 
@@ -93,6 +93,7 @@ All User Content must:
 - Be accurate and not misleading
 - Respect intellectual property rights
 - Not contain harmful, offensive, or inappropriate material
+- Not depict identifiable persons without their permission
 - Comply with applicable laws and regulations
 - Not promote dangerous or illegal activities
 
@@ -105,6 +106,8 @@ When interacting with other users:
 - Respect privacy and personal boundaries
 - Report inappropriate behavior
 - Follow our community moderation policies
+
+**Content moderation**: We do not pre-screen User Content before it is published. We moderate based on reports from users (see Section 7.5) and our own review; we do not use automated content moderation tools. Where Content violates these Terms or applicable law, we may remove it, issue a warning, or suspend or terminate the Account involved (see Sections 7.4 and 14.2).
 
 ## 7. User Content and Intellectual Property
 
@@ -127,11 +130,31 @@ You are solely responsible for your User Content and warrant that:
 
 ### 7.3 Our Content Rights
 
-All Service content, trademarks, logos, and intellectual property remain our exclusive property or that of our licensors.
+All content we provide through the Services — including text, images, graphics, logos, trademarks, blog posts, plant database content, growing guides, and other educational materials — is protected by copyright and other intellectual property rights and remains our exclusive property or that of our licensors.
+
+You may view and use this content within the Services for your own use, including in connection with planning and managing your own food forest. Without our prior written permission, you may not:
+
+- Copy, reproduce, or republish our text or images outside the Services
+- Scrape, extract, or systematically collect content (including the plant database), whether by automated or manual means
+- Distribute, sell, or otherwise commercially exploit our content
+- Modify our content or remove copyright or attribution notices
+
+Some content in the Services (such as images or plant data) is provided by third-party licensors and may be subject to additional license terms; the same restrictions apply to that content.
 
 ### 7.4 Content Removal
 
-We reserve the right to remove any Content that violates these Terms without prior notice.
+We may remove or disable access to Content that violates these Terms or applicable law. If we remove or restrict your Content, we will inform you of the decision and the reasons for it, unless we are legally prevented from doing so. If you disagree with our decision, you can object by contacting us at <hello@myfoodforest.nl>; we will review your objection diligently and respond in a timely manner.
+
+### 7.5 Reporting Illegal or Infringing Content
+
+If you believe that Content on our Services is illegal or infringes your rights (including copyright in text or images), you can report it to us at <hello@myfoodforest.nl> (subject: "Content report"). Please include:
+
+- A link to or a clear description of the Content and where it appears in the Services
+- An explanation of why you believe the Content is illegal or infringing
+- Your name and email address
+- A statement that you believe your report is accurate and submitted in good faith
+
+We will confirm receipt of your report, assess it diligently, timely, and in a non-arbitrary manner, and inform you of our decision. We may stop processing reports from persons who frequently submit manifestly unfounded reports, after first issuing a warning.
 
 ## 8. Privacy and Data Protection
 
@@ -274,7 +297,7 @@ If any provision of these Terms is found invalid or unenforceable, the remaining
 
 ## 19. Assignment
 
-We may assign these Terms or our rights hereunder. You may not assign your rights without our written consent.
+We may transfer our rights and obligations under these Terms to a third party in connection with a merger, acquisition, restructuring, or sale of assets. We will notify you of such a transfer, after which you may terminate your Account free of charge if you do not wish to continue with the new party. You may not assign your rights under these Terms without our written consent.
 
 ## 20. Changes to Terms
 
@@ -305,5 +328,5 @@ By using our Services, you acknowledge that you have read, understood, and agree
 
 *These Terms and Conditions are available in [Dutch](./TERMSANDCONDITIONS_NL.md).*
 
-**Document Version**: 1.1  
-**Effective Date**: June 4, 2026
+**Document Version**: 1.2  
+**Effective Date**: July 5, 2026

--- a/TERMSANDCONDITIONS_NL.md
+++ b/TERMSANDCONDITIONS_NL.md
@@ -329,4 +329,4 @@ Door onze Diensten te gebruiken, erkent u dat u deze Algemene Voorwaarden hebt g
 *Deze Algemene Voorwaarden zijn beschikbaar in het [Engels](./TERMSANDCONDITIONS_EN.md).*
 
 **Documentversie**: 1.2  
-**Ingangsdatum**: 5 juli 2026
+**Ingangsdatum**: 5 juni 2026

--- a/TERMSANDCONDITIONS_NL.md
+++ b/TERMSANDCONDITIONS_NL.md
@@ -1,7 +1,7 @@
 # Algemene Voorwaarden
 
 **My Food Forest B.V.**  
-Laatst bijgewerkt: 4 juni 2026
+Laatst bijgewerkt: 5 juni 2026
 
 ## 1. Inleiding en Aanvaarding
 
@@ -93,6 +93,7 @@ Alle Gebruikersinhoud moet:
 - Accuraat en niet misleidend zijn
 - Intellectuele eigendomsrechten respecteren
 - Geen schadelijk, aanstootgevend of ongepast materiaal bevatten
+- Geen herkenbare personen tonen zonder hun toestemming
 - Voldoen aan toepasselijke wetten en regelgeving
 - Geen gevaarlijke of illegale activiteiten promoten
 
@@ -105,6 +106,8 @@ Bij interactie met andere gebruikers:
 - Respecteer privacy en persoonlijke grenzen
 - Rapporteer ongepast gedrag
 - Volg ons moderatiebeleid voor de community
+
+**Inhoudsmoderatie**: Wij controleren Gebruikersinhoud niet vooraf voordat deze wordt gepubliceerd. Wij modereren op basis van meldingen van gebruikers (zie artikel 7.5) en onze eigen beoordeling; wij gebruiken geen geautomatiseerde moderatietools. Wanneer Inhoud deze Voorwaarden of toepasselijke wetgeving schendt, kunnen wij deze verwijderen, een waarschuwing geven, of het betrokken Account opschorten of beëindigen (zie artikelen 7.4 en 14.2).
 
 ## 7. Gebruikersinhoud en Intellectueel Eigendom
 
@@ -127,11 +130,31 @@ U bent uitsluitend verantwoordelijk voor uw Gebruikersinhoud en garandeert dat:
 
 ### 7.3 Onze Inhoudsrechten
 
-Alle serviceinhoud, handelsmerken, logo's en intellectueel eigendom blijven ons exclusieve eigendom of dat van onze licentiegevers.
+Alle inhoud die wij via de Diensten aanbieden — waaronder tekst, afbeeldingen, grafische elementen, logo's, handelsmerken, blogartikelen, inhoud van de plantendatabase, teeltgidsen en ander educatief materiaal — is beschermd door auteursrecht en andere intellectuele eigendomsrechten en blijft ons exclusieve eigendom of dat van onze licentiegevers.
+
+U mag deze inhoud binnen de Diensten bekijken en gebruiken voor eigen gebruik, waaronder voor het plannen en beheren van uw eigen voedselbos. Zonder onze voorafgaande schriftelijke toestemming mag u niet:
+
+- Onze tekst of afbeeldingen kopiëren, reproduceren of opnieuw publiceren buiten de Diensten
+- Inhoud (waaronder de plantendatabase) scrapen, extraheren of systematisch verzamelen, al dan niet geautomatiseerd
+- Onze inhoud verspreiden, verkopen of anderszins commercieel exploiteren
+- Onze inhoud wijzigen of auteursrecht- of bronvermeldingen verwijderen
+
+Sommige inhoud in de Diensten (zoals afbeeldingen of plantgegevens) wordt geleverd door externe licentiegevers en kan onderworpen zijn aan aanvullende licentievoorwaarden; voor die inhoud gelden dezelfde beperkingen.
 
 ### 7.4 Inhoud Verwijderen
 
-Wij behouden ons het recht voor om Inhoud die deze Voorwaarden schendt zonder voorafgaande kennisgeving te verwijderen.
+Wij kunnen Inhoud die deze Voorwaarden of toepasselijke wetgeving schendt verwijderen of ontoegankelijk maken. Als wij uw Inhoud verwijderen of beperken, informeren wij u over de beslissing en de redenen daarvoor, tenzij dit ons wettelijk niet is toegestaan. Als u het niet eens bent met onze beslissing, kunt u bezwaar maken door contact met ons op te nemen via <hello@myfoodforest.nl>; wij beoordelen uw bezwaar zorgvuldig en reageren tijdig.
+
+### 7.5 Melden van Illegale of Inbreukmakende Inhoud
+
+Als u van mening bent dat Inhoud op onze Diensten illegaal is of inbreuk maakt op uw rechten (waaronder auteursrecht op tekst of afbeeldingen), kunt u dit melden via <hello@myfoodforest.nl> (onderwerp: "Inhoudsmelding"). Vermeld daarbij:
+
+- Een link naar of duidelijke beschrijving van de Inhoud en de vindplaats binnen de Diensten
+- Een toelichting waarom u meent dat de Inhoud illegaal of inbreukmakend is
+- Uw naam en e-mailadres
+- Een verklaring dat u te goeder trouw meent dat uw melding juist is
+
+Wij bevestigen de ontvangst van uw melding, beoordelen deze zorgvuldig, tijdig en niet-willekeurig, en informeren u over onze beslissing. Wij kunnen de verwerking van meldingen staken van personen die herhaaldelijk kennelijk ongegronde meldingen indienen, na een voorafgaande waarschuwing.
 
 ## 8. Privacy en Gegevensbescherming
 
@@ -274,7 +297,7 @@ Als enige bepaling van deze Voorwaarden ongeldig of niet-afdwingbaar wordt bevon
 
 ## 19. Overdracht
 
-Wij kunnen deze Voorwaarden of onze rechten hieronder overdragen. U kunt uw rechten niet overdragen zonder onze schriftelijke toestemming.
+Wij kunnen onze rechten en verplichtingen onder deze Voorwaarden overdragen aan een derde in het kader van een fusie, overname, herstructurering of verkoop van activa. Wij stellen u van een dergelijke overdracht op de hoogte, waarna u uw Account kosteloos kunt beëindigen als u niet met de nieuwe partij verder wilt. U kunt uw rechten onder deze Voorwaarden niet overdragen zonder onze schriftelijke toestemming.
 
 ## 20. Wijzigingen in Voorwaarden
 
@@ -305,5 +328,5 @@ Door onze Diensten te gebruiken, erkent u dat u deze Algemene Voorwaarden hebt g
 
 *Deze Algemene Voorwaarden zijn beschikbaar in het [Engels](./TERMSANDCONDITIONS_EN.md).*
 
-**Documentversie**: 1.1  
-**Ingangsdatum**: 4 juni 2026
+**Documentversie**: 1.2  
+**Ingangsdatum**: 5 juli 2026


### PR DESCRIPTION
## Summary

Paralegal-style review of all four legal documents (Terms & Privacy, EN/NL), with all findings addressed. EN and NL versions kept fully parallel.

### Terms & Conditions (v1.2, effective June 5, 2026)
- **§7.3** — explicit copyright protection for our text, images, plant database content, and growing guides; permitted own use (incl. managing your own food forest); scraping/republishing prohibited; third-party licensed content covered
- **§6.3** — content moderation policy described (report-based, no automated tools) — DSA Art. 14
- **§7.4** — statement of reasons + objection route for content removal — DSA Art. 17
- **§7.5 (new)** — notice-and-action mechanism for reporting illegal/infringing content — DSA Art. 16
- **§19** — assignment limited to merger/acquisition/restructuring with notification and free termination right (art. 6:236(e) BW)
- **§6.2** — no depicting identifiable persons without permission
- Effective immediately: pre-launch, no existing users, so the §20.1 30-day notice obligation has no addressees

### Privacy Policy (v1.1, effective June 5, 2026)
- Weather data providers disclosed as recipients (§6.1); Mailchimp (Intuit) added as newsletter processor (§6.1, §13 context) with §7 international transfers updated accordingly
- EXIF/GPS metadata stripping on photo upload documented (§3.1)
- Retention rule added for company-terminated accounts (§8)
- Verification data disclosed (§3.1); profile location vs GPS location clarified (§3.1/3.2)
- GDPR response extension (Art. 12(3)) noted (§9); other-member-state supervisory authority complaints (§15)
- Version/effective-date footer added; terminology aligned ("Terms and Conditions")

## Before merging / publishing
- [ ] Counsel review of §19 (assignment) and the immediate effective date
- [ ] Verify backend strips EXIF on **all** photo upload paths (policy now asserts this)
- [ ] Confirm Mailchimp data processing addendum is in place (§6.1 asserts Art. 28 DPAs)

> Note: post-launch, material Terms changes will require the §20.1 30-day advance notice — immediate effectiveness only works while there are no users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)