### PR TITLE
docs: add security policy link to org profile contact section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -37,8 +37,9 @@ Whether you're just starting out or have years of experience, our app is here to
 Want to know more or get involved?
 
 - 🌍 **Website**: [www.myfoodforest.nl](https://www.myfoodforest.nl)
-- 🔐 **Privacy Policy**  [Privacy Policy](../PRIVACY_EN.md)
-- 💼 **Terms & Conditions** [Terms and Conditions](../TERMSANDCONDITIONS_EN.md)
+- 🔐 **Privacy Policy**: [Privacy Policy](../PRIVACY_EN.md)
+- 💼 **Terms & Conditions**: [Terms and Conditions](../TERMSANDCONDITIONS_EN.md)
+- 🛡️ **Security**: Found a vulnerability? See our [Security Policy](../SECURITY.md) or email <security@myfoodforest.nl>
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a Security line to the Contact section of the org profile README (shown at github.com/MyFoodForest), linking to the new SECURITY.md and the security@myfoodforest.nl reporting address. Also adds the missing colons on the Privacy Policy and Terms & Conditions lines for consistency.

Follow-up to #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)