### PR TITLE
fix: replace dead NCSC CVD guideline link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 **My Food Forest B.V.**
 Last updated: June 5, 2026
 
-We take the security of our services and our users' data seriously. We value the work of security researchers and welcome reports of vulnerabilities, in line with the [NCSC Coordinated Vulnerability Disclosure guideline](https://english.ncsc.nl/publications/publications/2019/juni/01/coordinated-vulnerability-disclosure-the-guideline).
+We take the security of our services and our users' data seriously. We value the work of security researchers and welcome reports of vulnerabilities, in line with the [NCSC Coordinated Vulnerability Disclosure guideline](https://www.ncsc.nl/api/media/sites/default/files/Coordinated_Vulnerability_Disclosure_the_Guideline.pdf) (PDF).
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

The NCSC link in SECURITY.md returned 404 — the `english.ncsc.nl` publication pages were removed in the NCSC site restructure (old domain now redirects to `www.ncsc.nl/en/` but the path is gone).

Verified alternatives (checked with curl):
- ❌ `english.ncsc.nl/publications/...` → 404
- ❌ `english.ncsc.nl/get-to-work/...` → 404
- ✅ Guideline PDF on `www.ncsc.nl` → **200** (now linked)
- ✅ `www.ncsc.nl/en/services/report-a-vulnerability` → 200 (NCSC's own reporting page — not used, different purpose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)