### PR TITLE
docs: expand §12.1 with plant and food safety disclaimer

### DIFF
--- a/TERMSANDCONDITIONS_EN.md
+++ b/TERMSANDCONDITIONS_EN.md
@@ -199,9 +199,9 @@ Our Services may integrate with or link to third-party services (such as weather
 
 ### 12.1 Agricultural, Plant, and Food Safety Disclaimer
 
-- Information in the Services (including the plant database, growing guides, recipes, and Content from other users) is general and educational in nature and may contain errors or omissions
+- Information in the Services (including the plant database, growing guides, recipes, and User Content posted by other users) is general and educational in nature and may contain errors or omissions
 - **Never eat any plant, fruit, mushroom, or other product based solely on information in the Services.** Always verify the identification, edibility, and required preparation method (for example, plants that are only safe to eat after cooking) with authoritative sources or qualified experts before consumption
-- Plants can be misidentified; some species have toxic lookalikes, are toxic in certain parts, raw form, or quantities, or can cause allergic reactions
+- Plants can be misidentified; some species have toxic lookalikes, are toxic in certain parts, when eaten raw, or in certain quantities, or can cause allergic reactions
 - We do not guarantee growing success or plant survival
 - Users should verify information with local experts and consider local climate, soil, and regulations
 - We are not responsible for crop failures or losses

--- a/TERMSANDCONDITIONS_EN.md
+++ b/TERMSANDCONDITIONS_EN.md
@@ -197,12 +197,13 @@ Our Services may integrate with or link to third-party services (such as weather
 
 ## 12. Disclaimers and Limitations
 
-### 12.1 Agricultural Information Disclaimer
+### 12.1 Agricultural, Plant, and Food Safety Disclaimer
 
-- Information provided is for educational purposes only
+- Information in the Services (including the plant database, growing guides, recipes, and Content from other users) is general and educational in nature and may contain errors or omissions
+- **Never eat any plant, fruit, mushroom, or other product based solely on information in the Services.** Always verify the identification, edibility, and required preparation method (for example, plants that are only safe to eat after cooking) with authoritative sources or qualified experts before consumption
+- Plants can be misidentified; some species have toxic lookalikes, are toxic in certain parts, raw form, or quantities, or can cause allergic reactions
 - We do not guarantee growing success or plant survival
-- Users should verify information with local experts
-- Consider local climate, soil, and regulations
+- Users should verify information with local experts and consider local climate, soil, and regulations
 - We are not responsible for crop failures or losses
 
 ### 12.2 Service Disclaimers

--- a/TERMSANDCONDITIONS_NL.md
+++ b/TERMSANDCONDITIONS_NL.md
@@ -197,12 +197,13 @@ Onze Diensten kunnen integreren met of linken naar diensten van derden (zoals we
 
 ## 12. Disclaimers en Beperkingen
 
-### 12.1 Landbouwinformatie Disclaimer
+### 12.1 Disclaimer Landbouw-, Planten- en Voedselveiligheidsinformatie
 
-- Verstrekte informatie is alleen voor educatieve doeleinden
+- Informatie in de Diensten (waaronder de plantendatabase, teeltgidsen, recepten en Inhoud van andere gebruikers) is algemeen en educatief van aard en kan fouten of omissies bevatten
+- **Eet nooit een plant, vrucht, paddenstoel of ander product uitsluitend op basis van informatie in de Diensten.** Controleer vóór consumptie altijd de determinatie, eetbaarheid en vereiste bereidingswijze (bijvoorbeeld planten die alleen na verhitting veilig eetbaar zijn) bij gezaghebbende bronnen of deskundigen
+- Planten kunnen worden verwisseld; sommige soorten hebben giftige gelijkende soorten, zijn giftig in bepaalde delen, rauwe vorm of hoeveelheden, of kunnen allergische reacties veroorzaken
 - Wij garanderen geen teeltsucces of plantenoverleving
-- Gebruikers moeten informatie verifiëren bij lokale experts
-- Houd rekening met lokaal klimaat, bodem en regelgeving
+- Verifieer informatie bij lokale experts en houd rekening met lokaal klimaat, bodem en regelgeving
 - Wij zijn niet verantwoordelijk voor gewasuitval of verliezen
 
 ### 12.2 Service Disclaimers

--- a/TERMSANDCONDITIONS_NL.md
+++ b/TERMSANDCONDITIONS_NL.md
@@ -199,9 +199,9 @@ Onze Diensten kunnen integreren met of linken naar diensten van derden (zoals we
 
 ### 12.1 Disclaimer Landbouw-, Planten- en Voedselveiligheidsinformatie
 
-- Informatie in de Diensten (waaronder de plantendatabase, teeltgidsen, recepten en Inhoud van andere gebruikers) is algemeen en educatief van aard en kan fouten of omissies bevatten
+- Informatie in de Diensten (waaronder de plantendatabase, teeltgidsen, recepten en Gebruikersinhoud van andere gebruikers) is algemeen en educatief van aard en kan fouten of omissies bevatten
 - **Eet nooit een plant, vrucht, paddenstoel of ander product uitsluitend op basis van informatie in de Diensten.** Controleer vóór consumptie altijd de determinatie, eetbaarheid en vereiste bereidingswijze (bijvoorbeeld planten die alleen na verhitting veilig eetbaar zijn) bij gezaghebbende bronnen of deskundigen
-- Planten kunnen worden verwisseld; sommige soorten hebben giftige gelijkende soorten, zijn giftig in bepaalde delen, rauwe vorm of hoeveelheden, of kunnen allergische reacties veroorzaken
+- Planten kunnen worden verwisseld; sommige soorten hebben giftige gelijkende soorten, zijn giftig in bepaalde delen, in rauwe vorm of in bepaalde hoeveelheden, of kunnen allergische reacties veroorzaken
 - Wij garanderen geen teeltsucces of plantenoverleving
 - Verifieer informatie bij lokale experts en houd rekening met lokaal klimaat, bodem en regelgeving
 - Wij zijn niet verantwoordelijk voor gewasuitval of verliezen


### PR DESCRIPTION
## Summary

Expands Terms §12.1 (EN/NL) from a growing-only disclaimer to cover **consumption safety** — the highest-risk scenario for a food forest app:

- Plant database, growing guides, recipes, and community content flagged as general/educational, may contain errors
- Explicit instruction: **never eat anything based solely on app information** — verify identification, edibility, and required preparation (e.g. cook-before-eating) with authoritative sources first
- Names the concrete risks: misidentification, toxic lookalikes, partially/raw-toxic species, quantity-dependent toxicity, allergies

Deliberately phrased as a user verification duty, **not** a liability exclusion for personal injury — that would be void under Dutch law (and §12.3 already correctly carves out death/injury). The disclaimer works by preventing fault, not by capping it.

Version stays **1.2** (same pre-launch release as #10).

## Follow-up

The disclaimer must also appear in the mobile app on **all plant detail pages** — tracked in MyFoodForest/mobileapp#170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)