### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every path is owned, so no pull request can satisfy code-owner review vacuously.
+*  @markscholman


### PR DESCRIPTION
Adds whole-repo CODEOWNERS. Inert until `require_code_owner_review` is enabled on the main ruleset.

Part of the Bramble develop-approval gate — see MyFoodForest/ops PR #1.